### PR TITLE
Included a fix that didn't allow for the time delta to be switched

### DIFF
--- a/GUI Code/sptPALMParam.m
+++ b/GUI Code/sptPALMParam.m
@@ -547,11 +547,10 @@ else
     msdFit = handles.msdFit;
 end
 % Time delta check
-% Test for GitHub
 if isequal(handles.deltaTime,0)
     deltaTime = defaultParameters.DefaultTimeDelta;
 else
-    deltaTime = handles.timeDelta;
+    deltaTime = handles.deltaTime;
 end
 % Mob Immob cutoff check
 if isequal(handles.miCutoff,0)


### PR DESCRIPTION
Edited sptPALMParam.m to define the correct time delta variable.

Line 553 read deltaTime = handles.timeDelta instead of the corrected deltaTime = handles.deltaTime.

Tested and fixed.